### PR TITLE
Adding state editingNote page

### DIFF
--- a/src/app/states/editing-note/page.mdx
+++ b/src/app/states/editing-note/page.mdx
@@ -5,7 +5,7 @@ export const metadata = {
 
 # editingNote
 
-An [app state](/guides/flux-architecture) of the currently opened note in the editor
+An [app state](/guides/flux-architecture) of the currently opened note in the editor.
 You can obtain the `editingNote` state and integrate it with React components.{{ className: 'lead' }}
 
 

--- a/src/app/states/editing-note/page.mdx
+++ b/src/app/states/editing-note/page.mdx
@@ -37,4 +37,4 @@ You can obtain the `editingNote` state and integrate it with React components.{{
   </Col>
 </Row>
 
-[note]: /reference/data-models#a-nameresource-notenotea
+[note]: /data-access/notes

--- a/src/app/states/editing-note/page.mdx
+++ b/src/app/states/editing-note/page.mdx
@@ -1,0 +1,44 @@
+export const metadata = {
+  title: 'editingNote',
+  description: 'An app state of editingNote in Inkdrop. This section explains how to fetch the `editingNote` state.',
+}
+
+# editingNote
+
+An [app state](/guides/flux-architecture) of editingNote in Inkdrop.
+You can obtain the `books` state and integrate it with React components.{{ className: 'lead' }}
+
+
+---
+
+## Data Structure
+
+<Row>
+  <Col>
+    <Properties>
+      <Property name="all" type="Book[]">
+        The state represents [Note][note] data while a note opened, otherwise it's `null` or `undefined`.
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    Get the `editingNote` state manually:
+
+    ```js
+    const { editingNote } = inkdrop.store.getState()
+    ```
+
+    Connect the state with your React component:
+
+    ```js
+    import { useSelector } from 'react-redux'
+    const selector = ({ editingNote }) => editingNote
+    const MyComponent = props => {
+      const editingNote = useSelector(selector)
+      // render
+    }
+    ```
+  </Col>
+</Row>
+
+[note]: /reference/data-models#a-nameresource-notenotea

--- a/src/app/states/editing-note/page.mdx
+++ b/src/app/states/editing-note/page.mdx
@@ -1,6 +1,6 @@
 export const metadata = {
   title: 'editingNote',
-  description: 'An app state of editingNote in Inkdrop. This section explains how to fetch the `editingNote` state.',
+  description: 'An app state of currently opened note in the editor. This section explains how to fetch the `editingNote` state.',
 }
 
 # editingNote

--- a/src/app/states/editing-note/page.mdx
+++ b/src/app/states/editing-note/page.mdx
@@ -15,11 +15,7 @@ You can obtain the `editingNote` state and integrate it with React components.{{
 
 <Row>
   <Col>
-    <Properties>
-      <Property name="all" type="Book[]">
-        The state represents [Note][note] data while a note opened, otherwise it's `null` or `undefined`.
-      </Property>
-    </Properties>
+    The state represents [Note][note] data while a note opened, otherwise it's `null` or `undefined`.
   </Col>
   <Col sticky>
     Get the `editingNote` state manually:

--- a/src/app/states/editing-note/page.mdx
+++ b/src/app/states/editing-note/page.mdx
@@ -5,8 +5,8 @@ export const metadata = {
 
 # editingNote
 
-An [app state](/guides/flux-architecture) of editingNote in Inkdrop.
-You can obtain the `books` state and integrate it with React components.{{ className: 'lead' }}
+An [app state](/guides/flux-architecture) of the currently opened note in the editor
+You can obtain the `editingNote` state and integrate it with React components.{{ className: 'lead' }}
 
 
 ---

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -240,7 +240,7 @@ export const navigation = [
     title: 'App States',
     links: [
       { title: 'Notebooks', href: '/states/books' },
-      { title: 'editingNote', href: '/states/editing-note' },
+      { title: 'Currently open note', href: '/states/editing-note' },
       { title: 'Preview', href: '/states/preview' },
     ],
   },

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -240,7 +240,7 @@ export const navigation = [
     title: 'App States',
     links: [
       { title: 'Notebooks', href: '/states/books' },
-      { title: 'Currently open note', href: '/states/editing-note' },
+      { title: 'Currently opened note', href: '/states/editing-note' },
       { title: 'Preview', href: '/states/preview' },
     ],
   },

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -240,6 +240,7 @@ export const navigation = [
     title: 'App States',
     links: [
       { title: 'Notebooks', href: '/states/books' },
+      { title: 'editingNote', href: '/states/editing-note' },
       { title: 'Preview', href: '/states/preview' },
     ],
   },


### PR DESCRIPTION
Adding the editingNote state page based on the info in [this](https://github.com/inkdropapp/docs/blob/master/src/pages/reference/state-editing-note.md) page.