### PR TITLE
add `event-kit` section

### DIFF
--- a/src/app/event-subscription/composite-disposable/page.mdx
+++ b/src/app/event-subscription/composite-disposable/page.mdx
@@ -1,0 +1,153 @@
+export const metadata = {
+  title: 'Composite Disposable',
+  description: 'An object that aggregates multiple Disposable instances together into a single disposable, so they can all be disposed as a group.',
+}
+
+# Composite Disposable
+
+An object that aggregates multiple [Disposable][disposable] instances together into a single disposable, so they can all be disposed as a group.
+
+These are very useful when subscribing to multiple events.
+
+```js
+import { CompositeDisposable } from 'event-kit'
+
+class Something {
+  constructor() {
+    this.disposables = new CompositeDisposable();
+    const db = inkdrop.main.dataStore.getLocalDB();
+
+    this.disposables.add(db.onChange(() => {}));
+    this.disposables.add(db.onNoteChange(() => {}));
+  }
+
+  destroy() {
+    this.disposables.dispose();
+  }
+}
+```
+
+
+
+---
+
+## Construction {{ label: 'constructor()' }}
+
+<Row>
+  <Col>
+    Construct an instance, optionally with one or more disposables.
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const subscriptions = new CompositeDisposable();
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Destruction {{ label: 'dispose()' }}
+
+<Row>
+  <Col>
+    Dispose all disposables added to this composite disposable.
+    If this object has already been disposed, this method has no effect.
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const subscriptions = new CompositeDisposable();
+
+    // Later, dispose all
+    subscriptions.dispose();
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Add multiple Disposables {{ label: 'add(...disposables)' }}
+
+<Row>
+  <Col>
+    Add disposables to be disposed when the composite is disposed.
+    If this object has already been disposed, this method has no effect.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="disposables" type="DisposableLike[]" required>
+        [Disposable][disposable] instances or any objects with `.dispose()`
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const subscriptions = new CompositeDisposable()
+
+    const db = inkdrop.main.dataStore.getLocalDB();
+    subscriptions.add(db.onChange(() => {}));
+    subscriptions.add(db.onNoteChange(() => {}));
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Remove a Disposable {{ label: 'remove(disposable)' }}
+
+<Row>
+  <Col>
+    Remove a previously added disposable.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="disposable" type="DisposableLike" required>
+        [Disposable][disposable] instances or any objects with `.dispose()`
+      </Property>
+    </Properties>
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const subscriptions = new CompositeDisposable()
+
+    const db = inkdrop.main.dataStore.getLocalDB();
+    const disposable = db.onNoteChange(() => {});
+    subscriptions.add(disposable);
+
+    // Later, remove the disposable
+    subscriptions.remove(disposable);
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Clear all disposables {{ label: 'clear()' }}
+
+<Row>
+  <Col>
+    Clear all disposables. They will not be disposed by the next call to dispose.
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const subscriptions = new CompositeDisposable()
+
+    // ...
+
+    subscriptions.clear();
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+[disposable]: /event-subscription/disposable

--- a/src/app/event-subscription/disposable/page.mdx
+++ b/src/app/event-subscription/disposable/page.mdx
@@ -1,0 +1,92 @@
+export const metadata = {
+  title: 'Disposable',
+  description: 'A handle to a resource that can be disposed.',
+}
+
+# Disposable
+
+A handle to a resource that can be disposed.
+You can use it by requiring [event-kit](https://github.com/atom/event-kit) module.
+
+```js
+import { Disposable } from 'event-kit'
+```
+
+---
+
+## Construction {{ label: 'constructor(disposalAction)' }}
+
+<Row>
+  <Col>
+    Construct a Disposable
+
+    ### Parameters
+
+    <Properties>
+      <Property name="disposalAction" type="(() => void) | undefined" required>
+        A Function to call when `.dispose()` is called for the first time.
+      </Property>
+    </Properties>
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const disposable = new Disposable(() => this.destroyResource())
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Destruction {{ label: 'dispose()' }}
+
+<Row>
+  <Col>
+    Perform the disposal action, indicating that the resource associated with
+    this disposable is no longer needed. You can call this method more than
+    once, but the disposal action will only be performed the first time.
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    disposable.dispose();
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Check if disposable {{ label: 'Disposable.isDisposable(object)' }}
+
+<Row>
+  <Col>
+    Ensure that `object` correctly implements the `Disposable` contract.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="object" type="object" required>
+        A object.
+      </Property>
+    </Properties>
+
+    ### Return value
+    Returns a Boolean indicating whether `object` is a valid `Disposable`.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    class ExampleDisposable {
+        dispose() {
+            // ...
+        }
+    }
+    Disposable.isDisposable(new ExampleDisposable());
+    ```
+    </CodeGroup>
+  </Col>
+</Row>

--- a/src/app/event-subscription/emitter/page.mdx
+++ b/src/app/event-subscription/emitter/page.mdx
@@ -1,0 +1,221 @@
+export const metadata = {
+  title: 'Emitter',
+  description:
+    'Utility class to be used when implementing event-based APIs',
+}
+
+# Emitter
+
+Utility class to be used when implementing event-based APIs that allows for handlers registered via `::on` to be invoked with calls to `::emit`.
+Instances of this class are intended to be used internally by classes that expose an event-based API.
+You can use it by requiring [event-kit](https://github.com/atom/event-kit) module.
+
+```js
+import { Emitter } from 'event-kit'
+
+class User {
+  constructor() {
+    this.emitter = new Emitter()
+  }
+
+  onDidChangeName(callback) {
+    this.emitter.on('did-change-name', callback)
+  }
+
+  setName(name) {
+    if (name !== this.name) {
+      this.name = name
+      this.emitter.emit('did-change-name', name)
+    }
+
+    return this.name
+  }
+}
+```
+
+---
+
+## Construction {{ label: 'constructor()' }}
+
+<Row>
+  <Col>Construct an emitter.</Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+      ```js
+      const emitter = new Emitter();
+      ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Destruction {{ label: 'dispose()' }}
+
+<Row>
+  <Col>Unsubscribe all handlers.</Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    emitter.dispose();
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Clear subscribers {{ label: 'clear()' }}
+
+<Row>
+  <Col>Clear out any existing subscribers.</Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    emitter.clear();
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Event Subscription: Repeated execution {{ label: 'on<T>(eventName, handler)' }}
+
+<Row>
+  <Col>
+    Register the given handler function to be invoked whenever events by the given name are emitted via `::emit`.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="eventName" type="string" required>
+        String naming the event that you want to invoke the handler when emitted.
+      </Property>
+      <Property name="handler" type="(value?: T) => void" required>
+        Function to invoke when `::emit` is called with the given event name.
+        `T` is the type of the value passed when calling `::emit`.
+      </Property>
+    </Properties>
+
+    ### Return value
+    Returns a [Disposable][disposable].
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    emitter.on(
+        'did-change-name', 
+        (value) => console.log(value)
+    );
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Event Subscription: One-time execution {{ label: 'once<T>(eventName, handler)' }}
+
+<Row>
+  <Col>
+    Register the given handler function to be invoked the next time an events with the given name is emitted via `::emit`.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="eventName" type="string" required>
+        String naming the event that you want to invoke the handler when emitted.
+      </Property>
+      <Property name="handler" type="(value?: T) => void" required>
+        Function to invoke when `::emit` is called with the given event name.
+        `T` is the type of the value passed when calling `::emit`.
+      </Property>
+    </Properties>
+
+    ### Return value
+    Returns a [Disposable][disposable].
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    emitter.once(
+        'did-change-name',
+        (value) => console.log("Once", value)
+    );
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Event Subscription: Prioritized execution {{ label: 'preempt<T>(eventName, handler)' }}
+
+<Row>
+  <Col>
+    Register the given handler function to be invoked _before_ all other handlers existing at the time of subscription whenever events by the given name are emitted via `::emit`.
+
+    Use this method when you need to be the first to handle a given event. This could be required when a data structure in a parent object needs to be updated before third-party event handlers registered on a child object via a public API are invoked.
+    Your handler could itself be preempted via subsequent calls to this method, but this can be controlled by keeping methods based on `::preempt` private.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="eventName" type="string" required>
+        String naming the event that you want to invoke the handler when emitted.
+      </Property>
+      <Property name="handler" type="(value?: T) => void" required>
+        Function to invoke when `::emit` is called with the given event name.
+        `T` is the type of the value passed when calling `::emit`.
+      </Property>
+    </Properties>
+
+    ### Return value
+    Returns a [Disposable][disposable].
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    emitter.preempt(
+        'did-change-name',
+        (value) => console.log("First", value)
+    );
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Event Emission {{ label: 'emit<T>(eventName, value)' }}
+
+<Row>
+  <Col>
+    Invoke all handlers registered for the given event name.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="eventName" type="string" required>
+        The name of the event to emit. Handlers registered for the same name will be invoked.
+      </Property>
+      <Property name="value" type="T" required>
+        Callbacks will be invoked with this value as an argument.
+      </Property>
+    </Properties>
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    emitter.emit('did-change-name', "string value");
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+[disposable]: /event-subscription/disposable

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -247,6 +247,14 @@ export const navigation = [
       { title: 'Preview', href: '/states/preview' },
     ],
   },
+  {
+    title: 'Event Subscription (event-kit)',
+    links: [
+      { title: 'Disposable', href: '/event-subscription/disposable' },
+      { title: 'Composite Disposable', href: '/event-subscription/composite-disposable' },
+      { title: 'Emitter', href: '/event-subscription/emitter' },
+    ],
+  },
 ]
 
 export function Navigation(props) {


### PR DESCRIPTION
Adds documentation for event-kit. Based on the following pages of the old documentation.
- https://docs.inkdrop.app/reference/composite-disposable
- https://docs.inkdrop.app/reference/disposable
- https://docs.inkdrop.app/reference/emitter

Also added and reworked examples to fit the new style.