### PR TITLE
fix(states): types

### DIFF
--- a/src/app/states/books/page.mdx
+++ b/src/app/states/books/page.mdx
@@ -8,7 +8,6 @@ export const metadata = {
 An [app state](/guides/flux-architecture) of notebooks in Inkdrop.
 You can obtain the `books` state and integrate it with React components.{{ className: 'lead' }}
 
-
 ---
 
 ## Data Structure
@@ -16,13 +15,13 @@ You can obtain the `books` state and integrate it with React components.{{ class
 <Row>
   <Col>
     <Properties>
-      <Property name="all" type="Book[]">
+      <Property name="all" type="Array<Book>">
         An array of [Book][book]s.
       </Property>
-      <Property name="hash" type="{ [bookId]: Book }">
+      <Property name="hash" type="Record<string, Book>">
         A map where the keys are `bookId` and values are [Book][book].
       </Property>
-      <Property name="tree" type="BookTree">
+      <Property name="tree" type="Array<BookTreeItem>">
         An array of [Book][book]s with a tree structure. A Book that has child notebooks recursively has a `children` property. The `children` property follows the same structure as `tree`: an array of [Book][book]s.
       </Property>
       <Property name="lastUpdatedAt" type="number">

--- a/src/app/states/db/page.mdx
+++ b/src/app/states/db/page.mdx
@@ -21,11 +21,11 @@ You can obtain the `db` state and integrate it with React components.{{ classNam
         `true` if the database is currently syncing.
         `undefined` if it has not ever been synced yet since the app launched.
       </Property>
-      <Property name="lastSyncTime" type="number | undefined">
+      <Property name="lastSyncTime" type="number | null | undefined">
         The last datetime when the database finished syncing. 
         `undefined` if it has not ever been synced yet since the app launched.
       </Property>
-      <Property name="lastSyncError" type="Error | null">
+      <Property name="lastSyncError" type="Error | null | undefined">
         The last error ocurred while syncing.
       </Property>
     </Properties>

--- a/src/app/states/editor/page.mdx
+++ b/src/app/states/editor/page.mdx
@@ -35,7 +35,7 @@ You can obtain the `editor` state and integrate it with React components.{{ clas
       <Property name="savingNoteId" type="string | undefined">
         When the app is saving the note, it indicates its' note ID, otherwise will be `undefined`.
       </Property>
-      <Property name="lastError" type="AssistiveError | null">
+      <Property name="lastError" type="AssistiveError | undefined">
         The last error that occurred.
       </Property>   
     </Properties>


### PR DESCRIPTION
- Based on the type information (https://github.com/inkdropapp/types), a few corrections to the documentation.
- I also preferred the use of Array\<T\> and Record\<T\> instead of shorthand operators for readability.