### PR TITLE
feat(modules): add data-store and related pages

### DIFF
--- a/src/app/data-access/database/page.mdx
+++ b/src/app/data-access/database/page.mdx
@@ -1,0 +1,291 @@
+export const metadata = {
+  title: 'Inkdrop Database',
+  description:
+    'Provides ways to access the local database for managing notes, notebooks, tags and images.',
+}
+
+# Inkdrop Database
+
+Provides ways to access the local database for managing notes, notebooks, tags and images.
+
+An instance of this class can be got via `inkdrop.main.dataStore.getLocalDB()`.
+
+---
+
+## Properties
+
+<Properties>
+  <Property name="notes" type="DBNote">
+    An instance of [DBNote](/data-access/notes) with a set of management
+    methods.
+  </Property>
+  <Property name="books" type="DBBook">
+    An instance of [DBBook](/data-access/books) with a set of management
+    methods.
+  </Property>
+  <Property name="tags" type="DBTag">
+    An instance of [DBTag](/data-access/tags) with a set of management methods.
+  </Property>
+  <Property name="files" type="DBFile">
+    An instance of [DBFile](/data-access/files) with a set of management
+    methods.
+  </Property>
+  <Property name="utils" type="DBUtils">
+    An instance of [DBUtils](/data-access/utils) with a set of management
+    methods.
+  </Property>
+</Properties>
+
+---
+
+## Event Subscription: All changes {{ label: 'onChange(callback)' }}
+
+<Row>
+  <Col>
+    Invoke the given callback when the database has been changed.
+
+    ### Parameters
+    <Properties>
+      <Property name="callback" type="(PouchDB.Core.ChangesResponseChange<object>) => void">
+        A function which is called with an object indicating the [changes feed](https://pouchdb.com/guides/changes.html#understanding-changes).
+      </Property>
+    </Properties>
+
+    ### Returns
+
+    Returns a [Disposable][disposable] on which `.dispose()` can be called to unsubscribe.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const db = inkdrop.main.dataStore.getLocalDB()
+    const subscription = db.onChange(changes => {
+      console.log('Database has been changed', changes)
+    });
+
+    // Later, dispose
+    subscription.dispose();
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Event Subscription: Note changes {{ label: 'onNoteChange(callback)' }}
+
+<Row>
+  <Col>
+    Invoke the given callback when a note has been added, modified or deleted.
+
+    ### Parameters
+    <Properties>
+      <Property name="callback" type="(PouchDB.Core.ChangesResponseChange<Note>) => void">
+        A function which is called with an object indicating the [changes feed](https://pouchdb.com/guides/changes.html#understanding-changes).
+      </Property>
+    </Properties>
+
+    ### Returns
+
+    Returns a [Disposable][disposable] on which `.dispose()` can be called to unsubscribe.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const db = inkdrop.main.dataStore.getLocalDB()
+    const subscription = db.onNoteChange(changes => {
+      console.log('Note has been changed', changes)
+    });
+
+    // Later, dispose
+    subscription.dispose();
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Event Subscription: Book changes {{ label: 'onBookChange(callback)' }}
+
+<Row>
+  <Col>
+    Invoke the given callback when a notebook has been added, modified or deleted.
+
+    ### Parameters
+    <Properties>
+      <Property name="callback" type="(PouchDB.Core.ChangesResponseChange<Book>) => void">
+        A function which is called with an object indicating the [changes feed](https://pouchdb.com/guides/changes.html#understanding-changes).
+      </Property>
+    </Properties>
+
+    ### Returns
+
+    Returns a [Disposable][disposable] on which `.dispose()` can be called to unsubscribe.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const db = inkdrop.main.dataStore.getLocalDB()
+    const subscription = db.onBookChange(changes => {
+      console.log('Notebook has been changed', changes)
+    });
+
+    // Later, dispose
+    subscription.dispose();
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Event Subscription: Tag changes {{ label: 'onTagChange(callback)' }}
+
+<Row>
+  <Col>
+    Invoke the given callback when a tag has been added, modified or deleted.
+
+    ### Parameters
+    <Properties>
+      <Property name="callback" type="(PouchDB.Core.ChangesResponseChange<Tag>) => void">
+        A function which is called with an object indicating the [changes feed](https://pouchdb.com/guides/changes.html#understanding-changes).
+      </Property>
+    </Properties>
+
+    ### Returns
+
+    Returns a [Disposable][disposable] on which `.dispose()` can be called to unsubscribe.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const db = inkdrop.main.dataStore.getLocalDB()
+    const subscription = db.onTagChange(changes => {
+      console.log('Tag has been changed', changes)
+    });
+
+    // Later, dispose
+    subscription.dispose();
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Event Subscription: Full-text index creation start {{ label: 'onFullTextIndexBuildStart(callback)' }}
+
+<Row>
+  <Col>
+    Invoke the given callback when the app started building full-text search index.
+
+    ### Parameters
+    <Properties>
+      <Property name="callback" type="() => void">
+        A Function to be invoked.
+      </Property>
+    </Properties>
+
+    ### Returns
+
+    Returns a [Disposable][disposable] on which `.dispose()` can be called to unsubscribe.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const db = inkdrop.main.dataStore.getLocalDB()
+    const subscription = db.onFullTextIndexBuildStart(changes => {
+      console.log('Full-text search index building has been started')
+    });
+
+    // Later, dispose
+    subscription.dispose();
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Event Subscription: Full-text index creation end {{ label: 'onFullTextIndexBuildEnd(callback)' }}
+
+<Row>
+  <Col>
+    Invoke the given callback when the app finished building full-text search index.
+
+    ### Parameters
+    <Properties>
+      <Property name="callback" type="() => void">
+        A Function to be invoked.
+      </Property>
+    </Properties>
+
+    ### Returns
+
+    Returns a [Disposable][disposable] on which `.dispose()` can be called to unsubscribe.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const db = inkdrop.main.dataStore.getLocalDB()
+    const subscription = db.onFullTextIndexBuildStart(changes => {
+      console.log('Full-text search index building has been finished')
+    });
+
+    // Later, dispose
+    subscription.dispose();
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Event Subscription: Full-text index creation error {{ label: 'onFullTextIndexBuildError(callback)' }}
+
+<Row>
+  <Col>
+    Invoke the given callback when the app failed to build full-text search index.
+
+    ### Parameters
+    <Properties>
+      <Property name="callback" type="(error: Error) => void">
+        A function which is called with an error.
+      </Property>
+    </Properties>
+
+    ### Returns
+
+    Returns a [Disposable][disposable] on which `.dispose()` can be called to unsubscribe.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const db = inkdrop.main.dataStore.getLocalDB()
+    const subscription = db.onFullTextIndexBuildStart(changes => {
+      console.log('Full-text search index building has been failed')
+    });
+
+    // Later, dispose
+    subscription.dispose();
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+[disposable]: /event-subscription/disposable

--- a/src/app/data-access/events/page.mdx
+++ b/src/app/data-access/events/page.mdx
@@ -1,44 +1,16 @@
 export const metadata = {
-  title: 'Inkdrop Database',
+  title: 'Events',
   description:
-    'Provides ways to access the local database for managing notes, notebooks, tags and images.',
+    'Provides the ability to subscribe to various events raised by the local database.',
 }
 
-# Inkdrop Database
+# Events
 
-Provides ways to access the local database for managing notes, notebooks, tags and images.
-
-An instance of this class can be got via `inkdrop.main.dataStore.getLocalDB()`.
+Provides the ability to subscribe to various events raised by the local database.
 
 ---
 
-## Properties
-
-<Properties>
-  <Property name="notes" type="DBNote">
-    An instance of [DBNote](/data-access/notes) with a set of management
-    methods.
-  </Property>
-  <Property name="books" type="DBBook">
-    An instance of [DBBook](/data-access/books) with a set of management
-    methods.
-  </Property>
-  <Property name="tags" type="DBTag">
-    An instance of [DBTag](/data-access/tags) with a set of management methods.
-  </Property>
-  <Property name="files" type="DBFile">
-    An instance of [DBFile](/data-access/files) with a set of management
-    methods.
-  </Property>
-  <Property name="utils" type="DBUtils">
-    An instance of [DBUtils](/data-access/utils) with a set of management
-    methods.
-  </Property>
-</Properties>
-
----
-
-## Event Subscription: All changes {{ label: 'onChange(callback)' }}
+## All changes {{ label: 'onChange(callback)' }}
 
 <Row>
   <Col>
@@ -74,7 +46,7 @@ An instance of this class can be got via `inkdrop.main.dataStore.getLocalDB()`.
 
 ---
 
-## Event Subscription: Note changes {{ label: 'onNoteChange(callback)' }}
+## Note changes {{ label: 'onNoteChange(callback)' }}
 
 <Row>
   <Col>
@@ -110,7 +82,7 @@ An instance of this class can be got via `inkdrop.main.dataStore.getLocalDB()`.
 
 ---
 
-## Event Subscription: Book changes {{ label: 'onBookChange(callback)' }}
+## Book changes {{ label: 'onBookChange(callback)' }}
 
 <Row>
   <Col>
@@ -146,7 +118,7 @@ An instance of this class can be got via `inkdrop.main.dataStore.getLocalDB()`.
 
 ---
 
-## Event Subscription: Tag changes {{ label: 'onTagChange(callback)' }}
+## Tag changes {{ label: 'onTagChange(callback)' }}
 
 <Row>
   <Col>
@@ -182,7 +154,7 @@ An instance of this class can be got via `inkdrop.main.dataStore.getLocalDB()`.
 
 ---
 
-## Event Subscription: Full-text index creation start {{ label: 'onFullTextIndexBuildStart(callback)' }}
+## Full-text index creation start {{ label: 'onFullTextIndexBuildStart(callback)' }}
 
 <Row>
   <Col>
@@ -218,7 +190,7 @@ An instance of this class can be got via `inkdrop.main.dataStore.getLocalDB()`.
 
 ---
 
-## Event Subscription: Full-text index creation end {{ label: 'onFullTextIndexBuildEnd(callback)' }}
+## Full-text index creation end {{ label: 'onFullTextIndexBuildEnd(callback)' }}
 
 <Row>
   <Col>
@@ -254,7 +226,7 @@ An instance of this class can be got via `inkdrop.main.dataStore.getLocalDB()`.
 
 ---
 
-## Event Subscription: Full-text index creation error {{ label: 'onFullTextIndexBuildError(callback)' }}
+## Full-text index creation error {{ label: 'onFullTextIndexBuildError(callback)' }}
 
 <Row>
   <Col>

--- a/src/app/modules/data-store/page.mdx
+++ b/src/app/modules/data-store/page.mdx
@@ -18,7 +18,7 @@ An instance of this class is always available as the `inkdrop.main.dataStore` gl
     If the user is not logged in yet, it is `undefined`.
   </Property>
   <Property name="local" type="InkdropDatabase">
-    An instance of [InkdropDatabase](/data-access/database) If the user is not logged in yet, it is `undefined`.
+    An instance of `InkdropDatabase` If the user is not logged in yet, it is `undefined`.
   </Property>
   <Property name="sync" type="InkdropDataSync">
     An instance of `InkdropDataSync`.
@@ -37,7 +37,7 @@ An instance of this class is always available as the `inkdrop.main.dataStore` gl
     No parameters
 
     ### Returns
-    Returns an instance of [InkdropDatabase](/data-access/database).
+    Returns an instance of `InkdropDatabase`.
     Throws an error if it's not loaded yet.
 
   </Col>

--- a/src/app/modules/data-store/page.mdx
+++ b/src/app/modules/data-store/page.mdx
@@ -1,0 +1,74 @@
+export const metadata = {
+  title: 'Data Store',
+  description: 'The class in the main process for dealing with database and sync.',
+}
+
+# Data Store
+
+The class in the main process for dealing with database and sync.
+An instance of this class is always available as the `inkdrop.main.dataStore` global.
+
+---
+
+## Properties
+
+<Properties>
+  <Property name="localPouch" type="PouchDB.Database">
+    An instance of [PouchDB](https://pouchdb.com) associated with the local database.
+    If the user is not logged in yet, it is `undefined`.
+  </Property>
+  <Property name="local" type="InkdropDatabase">
+    An instance of [InkdropDatabase](/data-access/database) If the user is not logged in yet, it is `undefined`.
+  </Property>
+  <Property name="sync" type="InkdropDataSync">
+    An instance of `InkdropDataSync`.
+  </Property>
+</Properties>
+
+---
+
+## Get local database {{ label: 'getLocalDB()' }}
+
+<Row>
+  <Col>
+    Gets the local database instance.
+
+    ### Parameters
+    No parameters
+
+    ### Returns
+    Returns an instance of [InkdropDatabase](/data-access/database).
+    Throws an error if it's not loaded yet.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    inkdrop.main.dataStore.getLocalDB()
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
+---
+
+## Update FTS Index {{ label: 'updateFTSIndex()' }}
+
+<Row>
+  <Col>
+    Triggers updating full-text search index.
+
+    ### Parameters
+    No parameters
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    inkdrop.main.dataStore.updateFTSIndex()
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+

--- a/src/app/modules/inkdrop-application/page.mdx
+++ b/src/app/modules/inkdrop-application/page.mdx
@@ -1,0 +1,22 @@
+export const metadata = {
+  title: 'Inkdrop Application',
+  description: 'The class in the main process for dealing with data store.',
+}
+
+# Inkdrop Application
+
+The class in the main process for dealing with data store.
+An instance of this class is always available as the `inkdrop.main` global.
+
+---
+
+## Properties
+
+<Properties>
+  <Property name="dataStore" type="DataStore">
+    A [DataStore](/modules/data-store) instance.
+  </Property>
+  <Property name="version" type="string">
+    String, indicating the app version.
+  </Property>
+</Properties>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -232,7 +232,7 @@ export const navigation = [
       { title: 'Tags', href: '/data-access/tags' },
       { title: 'Files', href: '/data-access/files' },
       { title: 'Utilities', href: '/data-access/utils' },
-      { title: 'Database', href: '/data-access/database' },
+      { title: 'Events', href: '/data-access/events' },
       { title: 'Local HTTP Server', href: '/data-access/local-http-server' },
     ],
   },

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -232,6 +232,7 @@ export const navigation = [
       { title: 'Tags', href: '/data-access/tags' },
       { title: 'Files', href: '/data-access/files' },
       { title: 'Utilities', href: '/data-access/utils' },
+      { title: 'Database', href: '/data-access/database' },
       { title: 'Local HTTP Server', href: '/data-access/local-http-server' },
     ],
   },
@@ -240,6 +241,8 @@ export const navigation = [
     links: [
       { title: 'Command Registry', href: '/modules/command-registry' },
       { title: 'Component Manager', href: '/modules/component-manager' },
+      { title: 'Data Store', href: '/modules/data-store' },
+      { title: 'Inkdrop Application', href: '/modules/inkdrop-application' },
       { title: 'Layout Manager', href: '/modules/layout-manager' },
       { title: 'Markdown Renderer', href: '/modules/markdown-renderer' },
     ],


### PR DESCRIPTION
Adds documentation for the data-store and related pages. Based on the following pages of the old documentation.

- https://docs.inkdrop.app/reference/data-store
- https://docs.inkdrop.app/reference/inkdrop-application
- https://docs.inkdrop.app/reference/inkdrop-database

As always, I have made some minor changes and added or updated some examples.

---

While migrating the documentation, I noticed that the structure/hierarchy could be revised in the future. In the documentation everything is shown on "one level", but in reality it looks different. I will make a proposal for this after the documentation migration is complete.