### PR TITLE
feat(modules): add markdown-editor

### DIFF
--- a/src/app/modules/markdown-editor/page.mdx
+++ b/src/app/modules/markdown-editor/page.mdx
@@ -1,0 +1,78 @@
+export const metadata = {
+  title: 'Markdown Editor',
+  description: 'Markdown editor React component.',
+}
+
+# Markdown Editor
+
+Markdown editor React component. An instance of this class will be loaded when you opened a note.
+You can access it as following:
+
+```js
+const mde = inkdrop.getActiveEditorOrThrowError()
+```
+
+If you are building a plugin that extends the editor, you have to subscribe events to know when it is loaded/unloaded:
+
+```js
+module.exports = {
+  activate() {
+    global.inkdrop.onEditorLoad(this.handleEditorDidLoad.bind(this))
+  },
+
+  deactivate() {
+    const editor = global.inkdrop.getActiveEditor()
+    if (editor) {
+      // unload
+    }
+  },
+
+  handleEditorDidLoad(editor) {
+    // extend the editor
+    const { cm } = editor
+  },
+}
+```
+
+For more information about accessing the editor, refer to [Environment](/modules/environment).
+
+---
+
+## Extending the Inkdrop Editor
+
+<Row>
+  <Col>
+    Inkdrop's editor is built on top of [CodeMirror](https://codemirror.net/5/).
+    You can access its instance via `mde.cm`.
+
+    All available CodeMirror APIs are [documented here](https://codemirror.net/doc/manual.html).
+
+  </Col>
+  <Col sticky>
+    For example, you can change an editor option like so:
+    <CodeGroup title="Example">
+
+      ```js
+      const mde = inkdrop.getActiveEditorOrThrowError()
+      mde.cm.setOption('lineNumbers', true)
+      ```
+
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Properties
+
+<Properties>
+  <Property name="cm" type="CodeMirror.Editor">
+    An instance of [CodeMirror v5](https://codemirror.net/5/).
+  </Property>
+  <Property name="wrapper" type="React.Component">
+    A React component that wraps [CodeMirror](https://codemirror.net/).
+  </Property>
+</Properties>
+
+---

--- a/src/app/modules/markdown-editor/page.mdx
+++ b/src/app/modules/markdown-editor/page.mdx
@@ -17,20 +17,26 @@ If you are building a plugin that extends the editor, you have to subscribe even
 ```js
 module.exports = {
   activate() {
-    global.inkdrop.onEditorLoad(this.handleEditorDidLoad.bind(this))
-  },
-
-  deactivate() {
-    const editor = global.inkdrop.getActiveEditor()
+    const editor = inkdrop.getActiveEditor()
     if (editor) {
-      // unload
+      this.extendEditor(editor)
+    } else {
+      inkdrop.onEditorLoad(this.extendEditor)
     }
   },
 
-  handleEditorDidLoad(editor) {
-    // extend the editor
+  deactivate() {
+    const editor = inkdrop.getActiveEditor()
+    if (editor) this.unextendEditor(editor)
+  },
+
+  extendEditor: (editor) => {
     const { cm } = editor
   },
+
+  unextendEditor: (editor) => {
+    // unload
+  }
 }
 ```
 

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -245,6 +245,7 @@ export const navigation = [
       { title: 'Inkdrop Application', href: '/modules/inkdrop-application' },
       { title: 'Layout Manager', href: '/modules/layout-manager' },
       { title: 'Markdown Renderer', href: '/modules/markdown-renderer' },
+      { title: 'Markdown Editor', href: '/modules/markdown-editor' },
     ],
   },
   {


### PR DESCRIPTION
Adds documentation for the markdown-editor. Based on the following page of the old documentation.

- https://docs.inkdrop.app/reference/mde

