### PR TITLE
feat(modules): add notification-manager

### DIFF
--- a/src/app/modules/notification-manager/page.mdx
+++ b/src/app/modules/notification-manager/page.mdx
@@ -1,0 +1,331 @@
+export const metadata = {
+  title: 'Notification Manager',
+  description:
+    'A notification manager used to create in-app Notifications that are shown to the user.',
+}
+
+# Notification Manager
+
+A notification manager used to create [Notification](/modules/notification)s to be shown to the user.
+An instance of this class is always available as the `inkdrop.notifications` global.
+
+---
+
+## Event Subscription: Notification added {{ label: 'onDidAddNotification(callback)' }}
+
+<Row>
+  <Col>
+    Invoke the given callback after a notification has been added.
+
+    ### Parameters
+    <Properties>
+      <Property name="callback" type="(notification: Notification) => void">
+        A function which is called when a notification is added with the added notification.
+      </Property>
+    </Properties>
+
+    ### Returns
+    Returns a [Disposable][disposable] on which `.dispose()` can be called to unsubscribe.
+
+  </Col>
+  <Col sticky>
+
+    <CodeGroup title="Example">
+    ```js
+    inkdrop.notifications.onDidAddNotification(notification => {
+      console.log('Notification added:', notification.getMessage())
+    })
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Event Subscription: Notifications cleared {{ label: 'onDidClearNotifications(callback)' }}
+
+<Row>
+  <Col>
+    Invoke the given callback after the notifications have been cleared.
+
+    ### Parameters
+    <Properties>
+      <Property name="callback" type="() => void">
+        A function which is called when the notifications are cleared.
+      </Property>
+    </Properties>
+
+    ### Returns
+    Returns a [Disposable][disposable] on which `.dispose()` can be called to unsubscribe.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    inkdrop.notifications.onDidClearNotifications(() => {
+      console.log('Notifications cleared')
+    })
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Get Notifications {{ label: 'getNotifications()' }}
+
+<Row>
+  <Col>
+    Get all the notifications.
+
+    ### Parameters
+    No parameters.
+
+    ### Returns
+    Returns an Array of [Notification](/modules/notification)s.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const notifications = inkdrop.notifications.getNotifications()
+    console.log('There are', notifications.length, 'notifications')
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Adding Notifications: Success {{ label: 'addSuccess(message, [options])' }}
+
+<Row>
+  <Col>
+    Add a success notification.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="message" type="string">
+        The message to display in the notification.
+      </Property>
+      <Property name="options" type="object">
+        An optional object to customize the notification.
+        <Properties sub>
+          <Property name="detail" type="string">
+            The detailed description to display in the notification.
+          </Property>
+          <Property name="dismissable" type="boolean">
+            Whether or not the notification can be dismissed by the user. Defaults to `false`.
+          </Property>
+        </Properties>
+      </Property>
+    </Properties>
+
+    ### Returns
+    Returns the [Notification](/modules/notification) that was added.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const notification = inkdrop.notifications.addSuccess(
+      'Success!', 
+      {
+        dismissable: true
+      }
+    )
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Adding Notifications: Info {{ label: 'addInfo(message, [options])' }}
+
+<Row>
+  <Col>
+    Add a info notification.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="message" type="string">
+        The message to display in the notification.
+      </Property>
+      <Property name="options" type="object">
+        An optional object to customize the notification.
+        <Properties sub>
+          <Property name="detail" type="string">
+            The detailed description to display in the notification.
+          </Property>
+          <Property name="dismissable" type="boolean">
+            Whether or not the notification can be dismissed by the user. Defaults to `false`.
+          </Property>
+        </Properties>
+      </Property>
+    </Properties>
+
+    ### Returns
+    Returns the [Notification](/modules/notification) that was added.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const notification = inkdrop.notifications.addInfo(
+      'Info!', 
+      {
+        dismissable: true
+      }
+    )
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Adding Notifications: Warning {{ label: 'addWarning(message, [options])' }}
+
+<Row>
+  <Col>
+    Add a warning notification.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="message" type="string">
+        The message to display in the notification.
+      </Property>
+      <Property name="options" type="object">
+        An optional object to customize the notification.
+        <Properties sub>
+          <Property name="detail" type="string">
+            The detailed description to display in the notification.
+          </Property>
+          <Property name="dismissable" type="boolean">
+            Whether or not the notification can be dismissed by the user. Defaults to `false`.
+          </Property>
+        </Properties>
+      </Property>
+    </Properties>
+
+    ### Returns
+    Returns the [Notification](/modules/notification) that was added.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const notification = inkdrop.notifications.addWarning(
+      'Warning!', 
+      {
+        dismissable: true
+      }
+    )
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Adding Notifications: Error {{ label: 'addError(message, [options])' }}
+
+<Row>
+  <Col>
+    Add a error notification.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="message" type="string">
+        The message to display in the notification.
+      </Property>
+      <Property name="options" type="object">
+        An optional object to customize the notification.
+        <Properties sub>
+          <Property name="detail" type="string">
+            The detailed description to display in the notification.
+          </Property>
+          <Property name="dismissable" type="boolean">
+            Whether or not the notification can be dismissed by the user. Defaults to `false`.
+          </Property>
+        </Properties>
+      </Property>
+    </Properties>
+
+    ### Returns
+    Returns the [Notification](/modules/notification) that was added.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const notification = inkdrop.notifications.addError(
+      'Error!', 
+      {
+        dismissable: true
+      }
+    )
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Adding Notifications: Fatal Error {{ label: 'addFatalError(message, [options])' }}
+
+<Row>
+  <Col>
+    Add a fatal error notification.
+
+    ### Parameters
+
+    <Properties>
+      <Property name="message" type="string">
+        The message to display in the notification.
+      </Property>
+      <Property name="options" type="object">
+        An optional object to customize the notification.
+        <Properties sub>
+          <Property name="detail" type="string">
+            The detailed description to display in the notification.
+          </Property>
+          <Property name="dismissable" type="boolean">
+            Whether or not the notification can be dismissed by the user. Defaults to `false`.
+          </Property>
+        </Properties>
+      </Property>
+    </Properties>
+
+    ### Returns
+    Returns the [Notification](/modules/notification) that was added.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    const notification = inkdrop.notifications.addFatalError(
+      'Fatal error!', 
+      {
+        dismissable: true
+      }
+    )
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+[disposable]: /event-subscription/disposable

--- a/src/app/modules/notification/page.mdx
+++ b/src/app/modules/notification/page.mdx
@@ -1,0 +1,181 @@
+export const metadata = {
+  title: 'Notification',
+  description: 'Represents an in-app notification.',
+}
+
+# Notification
+
+Represents an in-app notification.
+Notifications are rendered in the bottom right of the Application using the [Notification Manager](/modules/notification-manager).
+
+---
+
+## Properties
+
+<Properties>
+  <Property name="message" type="string">
+    Message of the notification.
+  </Property>
+  <Property
+    name="type"
+    type="'success' | 'info' | 'warning' | 'error' | 'fatal'"
+  >
+    Type of the notification.
+  </Property>
+</Properties>
+
+---
+
+## Event Subscription: Dissmissed {{ label: 'onDidDismiss(callback)' }}
+
+<Row>
+  <Col>
+    Invoke the given callback when the notification is dismissed.
+
+    ### Parameters
+    <Properties>
+      <Property name="callback" type="() => void">
+        A function which is called when the notification is dismissed.
+      </Property>
+    </Properties>
+
+    ### Returns
+    Returns a [Disposable][disposable] on which `.dispose()` can be called to unsubscribe.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    // Prepare: Create the notification
+    const notification = inkdrop.notifications.addInfo('Hello world!')
+
+    // Subscribe to the event
+    notification.onDidDismiss(() => {
+      console.log('Notification dismissed')
+    })
+    ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
+---
+
+## Event Subscription: Displayed {{ label: 'onDidDisplay(callback)' }}
+
+<Row>
+  <Col>
+    Invoke the given callback when the notification is displayed.
+
+    ### Parameters
+    <Properties>
+      <Property name="callback" type="() => void">
+        A function which is called when the notification is displayed.
+      </Property>
+    </Properties>
+
+    ### Returns
+    Returns a [Disposable][disposable] on which `.dispose()` can be called to unsubscribe.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    // Prepare: Create the notification
+    const notification = inkdrop.notifications.addInfo('Hello world!')
+
+    // Subscribe to the event
+    notification.onDidDisplay(() => {
+      console.log('Notification displayed')
+    })
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## getType {{ label: 'getType()' }}
+
+<Row>
+  <Col>
+    Gets the type of the notification.
+
+    ### Parameters
+    No parameters
+
+    ### Returns
+    Returns the type of the notification. (e.g. `'success'`)
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    // Prepare: Create the notification
+    const notification = inkdrop.notifications.addInfo('Hello world!')
+
+    // Get the type
+    notification.getType()
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## getMessage {{ label: 'getMessage()' }}
+
+<Row>
+  <Col>
+    Gets the message of the notification.
+
+    ### Parameters
+    No parameters
+
+    ### Returns
+    Returns the message of the notification.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    // Prepare: Create the notification
+    const notification = inkdrop.notifications.addInfo('Hello world!')
+
+    // Get the message
+    notification.getMessage()
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## dismiss {{ label: 'dismiss()' }}
+
+<Row>
+  <Col>
+    Dismisses the notification, removing it from the UI. Calling this programmatically will call all callbacks added via `onDidDismiss`.
+
+    ### Parameters
+    No parameters
+
+    ### Returns
+    No return value.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Example">
+    ```js
+    // Prepare: Create the notification
+    const notification = inkdrop.notifications.addInfo('Hello world!')
+
+    // Dismiss the notification
+    notification.dismiss()
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
+[disposable]: /event-subscription/disposable

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -245,6 +245,8 @@ export const navigation = [
       { title: 'Inkdrop Application', href: '/modules/inkdrop-application' },
       { title: 'Layout Manager', href: '/modules/layout-manager' },
       { title: 'Markdown Renderer', href: '/modules/markdown-renderer' },
+      { title: 'Notification', href: '/modules/notification' },
+      { title: 'Notification Manager', href: '/modules/notification-manager' },
     ],
   },
   {


### PR DESCRIPTION
Adds documentation for the notification-manager and related pages. Based on the following pages of the old documentation.

- https://docs.inkdrop.app/reference/notification-manager
- https://docs.inkdrop.app/reference/notification

As always, I have made some minor changes and added or updated some examples.