### PR TITLE
feat(navigation): add a list component

### DIFF
--- a/src/app/actions/page.mdx
+++ b/src/app/actions/page.mdx
@@ -1,0 +1,6 @@
+import { ListNavigationSection } from '@/components/ListNavigationSection'
+
+# App Actions
+
+<ListNavigationSection />
+

--- a/src/app/states/page.mdx
+++ b/src/app/states/page.mdx
@@ -1,0 +1,6 @@
+import { ListNavigationSection } from '@/components/ListNavigationSection'
+
+# App States
+
+<ListNavigationSection />
+

--- a/src/components/ListNavigationSection.jsx
+++ b/src/components/ListNavigationSection.jsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { usePathname } from "next/navigation"
+import Link from 'next/link'
+
+import { navigation } from "@/components/Navigation"
+
+export function ListNavigationSection() {
+  const currentPath = usePathname();
+  const section = navigation.filter(section => section.link === currentPath);
+  const links = section.length > 0 ? section[0].links : [];
+  return (
+    <ul>
+      { links.map(link => <li key={link.href}><Link href={link.href}>{link.title}</Link></li>) }
+      </ul>
+  );
+}
+

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -266,6 +266,7 @@ export const navigation = [
   },
   {
     title: 'App States',
+    link: "/states",
     links: [
       { title: 'Notebooks', href: '/states/books' },
       { title: 'Database', href: '/states/db' },
@@ -284,6 +285,7 @@ export const navigation = [
   },
   {
     title: 'App Actions',
+    link: "/actions",
     links: [
       { title: 'Editing note', href: '/actions/editing-note' },
       { title: 'Editor', href: '/actions/editor' },


### PR DESCRIPTION
While working on #22, I noticed that [this page]((https://developers.inkdrop.app/guides/flux-architecture)) contains a link to a page that displays a list of all pages in the section. (eg. https://docs.inkdrop.app/reference/actions)

This is an simple approach to transfer this behavior to the new docs as well.

Feel free to abandon this pr if it does not fit well enough.