### PR TITLE
fix(guides): add language identifier in code block

### DIFF
--- a/src/app/guides/plugin-word-count/page.mdx
+++ b/src/app/guides/plugin-word-count/page.mdx
@@ -523,8 +523,8 @@ Your package is now published and available on my.inkdrop.app. Head on over to h
 
 With `ipm publish`, you can bump the version and publish by using
 
-```
-$ ipm publish <version-type>
+```bash
+ipm publish <version-type>
 ```
 
 where `<version-type>` can be `major`, `minor` and `patch`.


### PR DESCRIPTION
Part of the command was not visible in the code block. Most likely `<version-type>` was parsed as a tag.