### PR TITLE
'Accessing the local database' page still mentions CSON config

### DIFF
--- a/src/app/guides/access-the-local-database/page.mdx
+++ b/src/app/guides/access-the-local-database/page.mdx
@@ -51,7 +51,7 @@ console.log('Search result:', docs)
 
 The Inkdrop client app can open a simple HTTP server so that you can access the data from an external program easily, which gives you a flexible ability to import/export your notes.
 
-You can configure the HTTP server settings by editing `config.cson` in [the user data directory](https://docs.inkdrop.app/manual/basic-usage#user-data-directory).
+You can configure the HTTP server settings by editing `config.json` in [the user data directory](https://docs.inkdrop.app/manual/basic-usage#user-data-directory).
 
 Quit Inkdrop, then edit it like so:
 


### PR DESCRIPTION
Inkdrop has been updated to 'json', instead of 'cson'.