### PR TITLE
Astro tutorial still mentions CSON config

### DIFF
--- a/src/app/guides/create-a-blog-using-astro/page.mdx
+++ b/src/app/guides/create-a-blog-using-astro/page.mdx
@@ -110,12 +110,12 @@ Even if you stopped using Inkdrop, the blog posts stay in your git repository. N
 Let's learn how to use it.
 
 As I mentioned above, live-export access to your data via the local Inkdrop server.
-So, you first have to enable it by editing the `config.cson` file stored in [the user data directory](https://docs.inkdrop.app/manual/basic-usage#user-data-directory):
+So, you first have to enable it by editing the `config.json` file stored in [the user data directory](https://docs.inkdrop.app/manual/basic-usage#user-data-directory):
 
-- on macOS: `~/Library/Application Support/inkdrop/config.cson`
-- on Windows: `%APPDATA%\inkdrop\config.cson`
-- on Linux(deb/rpm): `~/.config/inkdrop/config.cson`
-- on Linux(Snap): `~/snap/inkdrop/current/.config/inkdrop/config.cson`
+- on macOS: `~/Library/Application Support/inkdrop/config.json`
+- on Windows: `%APPDATA%\inkdrop\config.json`
+- on Linux(deb/rpm): `~/.config/inkdrop/config.json`
+- on Linux(Snap): `~/snap/inkdrop/current/.config/inkdrop/config.json`
 
 Quit Inkdrop, and add the following lines like so:
 


### PR DESCRIPTION
Inkdrop now uses 'json', instead of 'cson'