### PR TITLE
Typo on page.mdx

### DIFF
--- a/src/app/guides/text-annotations/page.mdx
+++ b/src/app/guides/text-annotations/page.mdx
@@ -13,7 +13,7 @@ This hacking tip requires some web development skill.
 GitHub Flavored Markdown(GFM) supports some emphasises like so:
 
 ```markdown
-Emphasis, aka italics, with _asterisks_ or _underscores_.
+Emphasis, aka italics, with *asterisks* or _underscores_.
 
 Strong emphasis, aka bold, with **asterisks** or **underscores**.
 


### PR DESCRIPTION
Example given uses underscores (_), instead of asterisks (*)